### PR TITLE
Update for OpenCV 4.x

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,19 +1,27 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.8)
 
 project(image_contrast_enhancement)
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
 
-find_package(OpenCV 3 REQUIRED)
-find_package(dlib REQUIRED)
-find_package(Armadillo REQUIRED)
+option(USE_ARMA "Use advanced dependences (arma, dlib)?" OFF)
+if (USE_ARMA)
+    add_definitions(-DUSE_ARMA)
+endif(USE_ARMA)
+
+
+find_package(OpenCV 4 REQUIRED)
+if (USE_ARMA)
+   find_package(dlib REQUIRED)
+   find_package(Armadillo REQUIRED)
+endif()
+
 include_directories(
     ${OpenCV_INCLUDE_DIRS}
-    ${ARMADILLO_INCLUDE_DIRS}
     include
 )
 
-add_executable(main 
+set(SOURCES
     src/util.cpp
     src/AINDANE.cpp
     src/WTHE.cpp
@@ -22,15 +30,22 @@ add_executable(main
     src/AGCWD.cpp
     src/AGCIE.cpp
     src/IAGCWD.cpp
-    src/Ying_2017_CAIP.cpp
     src/CEusingLuminanceAdaptation.cpp
     src/adaptiveImageEnhancement.cpp
     src/JHE.cpp
     src/SEF.cpp
     src/main.cpp
-)
-target_link_libraries(main  
-    ${OpenCV_LIBS} 
-    ${ARMADILLO_LIBRARIES}
-    dlib::dlib 
-)
+    include/image_enhancement.h
+    include/util.h)
+
+set(LIBS ${OpenCV_LIBS})
+
+if (USE_ARMA)
+     include_directories(${ARMADILLO_INCLUDE_DIRS})
+     set(SOURCES ${SOURCES} src/Ying_2017_CAIP.cpp)
+set(LIBS ${LIBS} ${ARMADILLO_LIBRARIES} dlib::dlib)
+endif()
+
+add_executable(main ${SOURCES})
+
+target_link_libraries(main ${LIBS})

--- a/include/image_enhancement.h
+++ b/include/image_enhancement.h
@@ -108,7 +108,7 @@ void AGCIE(const cv::Mat & src, cv::Mat & dst);
 ***/
 void IAGCWD(const cv::Mat & src, cv::Mat & dst, double alpha_dimmed = 0.75, double alpha_bright = 0.25, int T_t = 112, double tau_t = 0.3, double tau = 0.5);
 
-
+#ifdef USE_ARMA
 /***
 @inproceedings{ying2017new,
   title={A New Image Contrast Enhancement Algorithm Using Exposure Fusion Framework},
@@ -122,7 +122,7 @@ void IAGCWD(const cv::Mat & src, cv::Mat & dst, double alpha_dimmed = 0.75, doub
 This is a reimplementation from https://baidut.github.io/OpenCE/caip2017.html
 ***/
 void Ying_2017_CAIP(const cv::Mat& src, cv::Mat& dst, double mu = 0.5, double a = -0.3293, double b = 1.1258, double lambda = 0.5, double sigma = 5);
-
+#endif
 
 /***
 @article{fu2018retinex,

--- a/include/util.h
+++ b/include/util.h
@@ -4,13 +4,16 @@
 // This must be defnined, in order to use arma::spsolve in the code with SuperLU
 #define ARMA_USE_SUPERLU
 
+#ifdef USE_ARMA
 #include <armadillo>
+#endif
 #include <iostream>
 #include <opencv2/opencv.hpp>
 
+#ifdef USE_ARMA
 // This is a Armadillo-based implementation of spdiags in Matlab.
 arma::sp_mat spdiags(const arma::mat& B, const std::vector<int>& d, int m, int n);
-
+#endif
 
 enum ConvolutionType {
 	/* Return the full convolution, including border */

--- a/src/AGCIE.cpp
+++ b/src/AGCIE.cpp
@@ -17,7 +17,7 @@ void AGCIE(const cv::Mat & src, cv::Mat & dst)
 		L = src.clone();
 	}
 	else {
-		cv::cvtColor(src, HSV, CV_BGR2HSV_FULL);
+		cv::cvtColor(src, HSV, cv::COLOR_BGR2HSV_FULL);
 		cv::split(HSV, HSV_channels);
 		L = HSV_channels[2];
 	}
@@ -70,7 +70,7 @@ void AGCIE(const cv::Mat & src, cv::Mat & dst)
 	}
 	else {
 		cv::merge(HSV_channels, dst);
-		cv::cvtColor(dst, dst, CV_HSV2BGR_FULL);
+		cv::cvtColor(dst, dst, cv::COLOR_HSV2BGR_FULL);
 	}
 
 	return;

--- a/src/AGCWD.cpp
+++ b/src/AGCWD.cpp
@@ -17,7 +17,7 @@ void AGCWD(const cv::Mat & src, cv::Mat & dst, double alpha)
 		L = src.clone();
 	}
 	else {
-		cv::cvtColor(src, HSV, CV_BGR2HSV_FULL);
+		cv::cvtColor(src, HSV, cv::COLOR_BGR2HSV_FULL);
 		cv::split(HSV, HSV_channels);
 		L = HSV_channels[2];
 	}
@@ -62,7 +62,7 @@ void AGCWD(const cv::Mat & src, cv::Mat & dst, double alpha)
 	}
 	else {
 		cv::merge(HSV_channels, dst);
-		cv::cvtColor(dst, dst, CV_HSV2BGR_FULL);
+		cv::cvtColor(dst, dst, cv::COLOR_HSV2BGR_FULL);
 	}
 
 	return;

--- a/src/AINDANE.cpp
+++ b/src/AINDANE.cpp
@@ -6,7 +6,7 @@
 void AINDANE(const cv::Mat& src, cv::Mat& dst, int sigma1, int sigma2, int sigma3)
 {
     cv::Mat I;
-    cv::cvtColor(src, I, CV_BGR2GRAY);
+    cv::cvtColor(src, I, cv::COLOR_BGR2GRAY);
 
     int histsize = 256;
     float range[] = { 0, 256 };

--- a/src/CEusingLuminanceAdaptation.cpp
+++ b/src/CEusingLuminanceAdaptation.cpp
@@ -91,7 +91,7 @@ void CEusingLuminanceAdaptation(const cv::Mat& src, cv::Mat& dst)
 
     HSV_channels[2] = V_out;
     cv::merge(HSV_channels, HSV);
-    cv::cvtColor(HSV, dst, CV_HSV2BGR_FULL);
+    cv::cvtColor(HSV, dst, cv::COLOR_HSV2BGR_FULL);
 
     return;
 }

--- a/src/GCEHistMod.cpp
+++ b/src/GCEHistMod.cpp
@@ -16,7 +16,7 @@ void GCEHistMod(const cv::Mat& src, cv::Mat& dst, int threshold, int b, int w, d
     if (channels == 1) {
         L = src.clone();
     } else {
-        cv::cvtColor(src, HSV, CV_BGR2HSV_FULL);
+        cv::cvtColor(src, HSV, cv::COLOR_BGR2HSV_FULL);
         cv::split(HSV, HSV_channels);
         L = HSV_channels[2];
     }
@@ -71,7 +71,7 @@ void GCEHistMod(const cv::Mat& src, cv::Mat& dst, int threshold, int b, int w, d
         dst = L.clone();
     } else {
         cv::merge(HSV_channels, dst);
-        cv::cvtColor(dst, dst, CV_HSV2BGR_FULL);
+        cv::cvtColor(dst, dst, cv::COLOR_HSV2BGR_FULL);
     }
 
     return;

--- a/src/IAGCWD.cpp
+++ b/src/IAGCWD.cpp
@@ -17,7 +17,7 @@ void IAGCWD(const cv::Mat & src, cv::Mat & dst, double alpha_dimmed, double alph
 		L = src.clone();
 	}
 	else {
-		cv::cvtColor(src, HSV, CV_BGR2HSV_FULL);
+		cv::cvtColor(src, HSV, cv::COLOR_BGR2HSV_FULL);
 		cv::split(HSV, HSV_channels);
 		L = HSV_channels[2];
 	}
@@ -93,7 +93,7 @@ void IAGCWD(const cv::Mat & src, cv::Mat & dst, double alpha_dimmed, double alph
 	}
 	else {
 		cv::merge(HSV_channels, dst);
-		cv::cvtColor(dst, dst, CV_HSV2BGR_FULL);
+		cv::cvtColor(dst, dst, cv::COLOR_HSV2BGR_FULL);
 	}
 
 	return;

--- a/src/JHE.cpp
+++ b/src/JHE.cpp
@@ -17,7 +17,7 @@ void JHE(const cv::Mat & src, cv::Mat & dst)
 		L = src.clone();
 	}
 	else {
-		cv::cvtColor(src, YUV, CV_BGR2YUV);
+		cv::cvtColor(src, YUV, cv::COLOR_BGR2YUV);
 		cv::split(YUV, YUV_channels);
 		L = YUV_channels[0];
 	}
@@ -81,7 +81,7 @@ void JHE(const cv::Mat & src, cv::Mat & dst)
 	}
 	else {
 		cv::merge(YUV_channels, dst);
-		cv::cvtColor(dst, dst, CV_YUV2BGR);
+		cv::cvtColor(dst, dst, cv::COLOR_YUV2BGR);
 	}
 
 	return;

--- a/src/LDR.cpp
+++ b/src/LDR.cpp
@@ -15,7 +15,7 @@ void LDR(const cv::Mat& src, cv::Mat& dst, double alpha)
         Y = src.clone();
     } else {
         cv::Mat YUV;
-        cv::cvtColor(src, YUV, CV_BGR2YUV);
+        cv::cvtColor(src, YUV, cv::COLOR_BGR2YUV);
         cv::split(YUV, YUV_channels);
         Y = YUV_channels[0];
     }
@@ -106,7 +106,7 @@ void LDR(const cv::Mat& src, cv::Mat& dst, double alpha)
         dst = Y.clone();
     } else {
         cv::merge(YUV_channels, dst);
-        cv::cvtColor(dst, dst, CV_YUV2BGR);
+        cv::cvtColor(dst, dst, cv::COLOR_YUV2BGR);
     }
 
     return;

--- a/src/SEF.cpp
+++ b/src/SEF.cpp
@@ -98,19 +98,19 @@ void robust_normalization(const cv::Mat& src, cv::Mat& dst, double wSat = 1.0, d
 		cv::max(src_channels[0], src_channels[1], max_channel);
 		cv::max(max_channel, src_channels[2], max_channel);
 		cv::Mat max_channel_sort;
-		cv::sort(max_channel.reshape(1,1), max_channel_sort, CV_SORT_ASCENDING);
+		cv::sort(max_channel.reshape(1,1), max_channel_sort, cv::SORT_ASCENDING);
 		vmax = max_channel_sort.at<double>(int(N - wSat*N / 100 + 1));
 
 		cv::Mat min_channel;
 		cv::min(src_channels[0], src_channels[1], min_channel);
 		cv::min(min_channel, src_channels[2], min_channel);
 		cv::Mat min_channel_sort;
-		cv::sort(min_channel.reshape(1, 1), min_channel_sort, CV_SORT_ASCENDING);
+		cv::sort(min_channel.reshape(1, 1), min_channel_sort, cv::SORT_ASCENDING);
 		vmin = min_channel_sort.at<double>(int(bSat*N / 100));
 	}
 	else {
 		cv::Mat src_sort;
-		cv::sort(src.reshape(1, 1), src_sort, CV_SORT_ASCENDING);
+		cv::sort(src.reshape(1, 1), src_sort, cv::SORT_ASCENDING);
 		vmax = src_sort.at<double>(int(N - wSat*N / 100 + 1));
 		vmin = src_sort.at<double>(int(bSat*N / 100));
 	}
@@ -171,7 +171,7 @@ void SEF(const cv::Mat & src, cv::Mat & dst, double alpha, double beta, double l
 		L = src.clone();
 	}
 	else {
-		cv::cvtColor(src, HSV, CV_BGR2HSV_FULL);
+		cv::cvtColor(src, HSV, cv::COLOR_BGR2HSV_FULL);
 		cv::split(HSV, HSV_channels);
 		L = HSV_channels[2];
 	}
@@ -197,7 +197,7 @@ void SEF(const cv::Mat & src, cv::Mat & dst, double alpha, double beta, double l
 	// Compute median
 	cv::Mat tmp = src.reshape(1, 1);
 	cv::Mat sorted;
-	cv::sort(tmp, sorted, CV_SORT_ASCENDING);
+	cv::sort(tmp, sorted, cv::SORT_ASCENDING);
 	double med = double(sorted.at<uchar>(rows * cols * channels / 2)) / 255.0;
 	//std::cout << "med = " << med << std::endl;
 

--- a/src/WTHE.cpp
+++ b/src/WTHE.cpp
@@ -17,7 +17,7 @@ void WTHE(const cv::Mat & src, cv::Mat & dst, float r, float v)
 		L = src.clone();
 	}
 	else {
-		cv::cvtColor(src, YUV, CV_BGR2YUV);
+		cv::cvtColor(src, YUV, cv::COLOR_BGR2YUV);
 		cv::split(YUV, YUV_channels);
 		L = YUV_channels[0];
 	}
@@ -71,7 +71,7 @@ void WTHE(const cv::Mat & src, cv::Mat & dst, float r, float v)
 	}
 	else {
 		cv::merge(YUV_channels, dst);
-		cv::cvtColor(dst, dst, CV_YUV2BGR);
+		cv::cvtColor(dst, dst, cv::COLOR_YUV2BGR);
 	}
 
 	return;

--- a/src/adaptiveImageEnhancement.cpp
+++ b/src/adaptiveImageEnhancement.cpp
@@ -46,7 +46,7 @@ void adaptiveImageEnhancement(const cv::Mat& src, cv::Mat& dst)
     X2.copyTo(X(cv::Range(0, n), cv::Range(1, 2)));
 
     cv::Mat covar, mean;
-    cv::calcCovarMatrix(X, covar, mean, CV_COVAR_NORMAL | CV_COVAR_ROWS, CV_64F);
+    cv::calcCovarMatrix(X, covar, mean, cv::COVAR_NORMAL | cv::COVAR_ROWS, CV_64F);
 
     cv::Mat eigenValues; //The eigenvalues are stored in the descending order.
     cv::Mat eigenVectors; //The eigenvectors are stored as subsequent matrix rows.
@@ -61,7 +61,7 @@ void adaptiveImageEnhancement(const cv::Mat& src, cv::Mat& dst)
 
     HSV_channels[2] = F;
     cv::merge(HSV_channels, HSV);
-    cv::cvtColor(HSV, dst, CV_HSV2BGR_FULL);
+    cv::cvtColor(HSV, dst, cv::COLOR_HSV2BGR_FULL);
 
     return;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -47,6 +47,22 @@ int main(int argc, char** argv)
     end_time = high_resolution_clock::now();
     MyTimeOutput("LDR处理时间: ", start_time, end_time);
 
+	start_time = high_resolution_clock::now();
+	cv::Mat CLAHE_dst;
+	cv::Mat labImage;
+	cv::cvtColor(src, labImage, cv::COLOR_BGR2Lab);
+	std::vector<cv::Mat> labPlanes(3);
+	cv::split(labImage, labPlanes);
+	cv::Ptr<cv::CLAHE> clahe = cv::createCLAHE();
+	clahe->setClipLimit(4);
+	cv::Mat dst;
+	clahe->apply(labPlanes[0], dst);
+	dst.copyTo(labPlanes[0]);
+	cv::merge(labPlanes, labImage);
+	cv::cvtColor(labImage, CLAHE_dst, cv::COLOR_Lab2BGR);
+	end_time = high_resolution_clock::now();
+	MyTimeOutput("CLAHE处理时间: ", start_time, end_time);
+
     start_time = high_resolution_clock::now();
     cv::Mat AGCWD_dst;
     AGCWD(src, AGCWD_dst);
@@ -96,20 +112,35 @@ int main(int argc, char** argv)
     end_time = high_resolution_clock::now();
     MyTimeOutput("SEF处理时间: ", start_time, end_time);
 
+	cv::namedWindow("src", cv::WINDOW_NORMAL | cv::WINDOW_KEEPRATIO);
     cv::imshow("src", src);
+	cv::namedWindow("AINDANE_dst", cv::WINDOW_NORMAL | cv::WINDOW_KEEPRATIO);
     cv::imshow("AINDANE_dst", AINDANE_dst);
+	cv::namedWindow("WTHE_dst", cv::WINDOW_NORMAL | cv::WINDOW_KEEPRATIO);
     cv::imshow("WTHE_dst", WTHE_dst);
+	cv::namedWindow("GCEHistMod_dst", cv::WINDOW_NORMAL | cv::WINDOW_KEEPRATIO);
     cv::imshow("GCEHistMod_dst", GCEHistMod_dst);
+	cv::namedWindow("LDR_dst", cv::WINDOW_NORMAL | cv::WINDOW_KEEPRATIO);
     cv::imshow("LDR_dst", LDR_dst);
+	cv::namedWindow("CLAHE_dst", cv::WINDOW_NORMAL | cv::WINDOW_KEEPRATIO);
+    cv::imshow("CLAHE_dst", CLAHE_dst);
+	cv::namedWindow("AGCWD_dst", cv::WINDOW_NORMAL | cv::WINDOW_KEEPRATIO);
     cv::imshow("AGCWD_dst", AGCWD_dst);
+	cv::namedWindow("AGCIE_dst", cv::WINDOW_NORMAL | cv::WINDOW_KEEPRATIO);
     cv::imshow("AGCIE_dst", AGCIE_dst);
+	cv::namedWindow("IAGCWD_dst", cv::WINDOW_NORMAL | cv::WINDOW_KEEPRATIO);
     cv::imshow("IAGCWD_dst", IAGCWD_dst);
 #ifdef USE_ARMA
+	cv::namedWindow("Ying_dst", cv::WINDOW_NORMAL | cv::WINDOW_KEEPRATIO);
     cv::imshow("Ying_dst", Ying_dst);
 #endif
+	cv::namedWindow("CEusingLuminanceAdaptation_dst", cv::WINDOW_NORMAL | cv::WINDOW_KEEPRATIO);
     cv::imshow("CEusingLuminanceAdaptation_dst", CEusingLuminanceAdaptation_dst);
+	cv::namedWindow("adaptiveImageEnhancement_dst", cv::WINDOW_NORMAL | cv::WINDOW_KEEPRATIO);
     cv::imshow("adaptiveImageEnhancement_dst", adaptiveImageEnhancement_dst);
+	cv::namedWindow("JHE_dst", cv::WINDOW_NORMAL | cv::WINDOW_KEEPRATIO);
     cv::imshow("JHE_dst", JHE_dst);
+	cv::namedWindow("SEF_dst", cv::WINDOW_NORMAL | cv::WINDOW_KEEPRATIO);
     cv::imshow("SEF_dst", SEF_dst);
 	
     cv::waitKey();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -64,13 +64,14 @@ int main(int argc, char** argv)
     IAGCWD(src, IAGCWD_dst);
     end_time = high_resolution_clock::now();
     MyTimeOutput("IAGCWD处理时间: ", start_time, end_time);
-
+	
+#ifdef USE_ARMA
     start_time = high_resolution_clock::now();
     cv::Mat Ying_dst;
     Ying_2017_CAIP(src, Ying_dst);
     end_time = high_resolution_clock::now();
     MyTimeOutput("Ying处理时间: ", start_time, end_time);
-
+#endif
     start_time = high_resolution_clock::now();
     cv::Mat CEusingLuminanceAdaptation_dst;
     CEusingLuminanceAdaptation(src, CEusingLuminanceAdaptation_dst);
@@ -103,7 +104,9 @@ int main(int argc, char** argv)
     cv::imshow("AGCWD_dst", AGCWD_dst);
     cv::imshow("AGCIE_dst", AGCIE_dst);
     cv::imshow("IAGCWD_dst", IAGCWD_dst);
+#ifdef USE_ARMA
     cv::imshow("Ying_dst", Ying_dst);
+#endif
     cv::imshow("CEusingLuminanceAdaptation_dst", CEusingLuminanceAdaptation_dst);
     cv::imshow("adaptiveImageEnhancement_dst", adaptiveImageEnhancement_dst);
     cv::imshow("JHE_dst", JHE_dst);

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1,12 +1,12 @@
 // This must be defnined, in order to use arma::spsolve in the code with SuperLU
 #define ARMA_USE_SUPERLU
 
-#include <armadillo>
 #include <iostream>
 #include <opencv2/opencv.hpp>
 
 #include "util.h"
 
+#ifdef USE_ARMA
 arma::sp_mat spdiags(const arma::mat& B, const std::vector<int>& d, int m, int n)
 {
     arma::sp_mat A(m, n);
@@ -18,7 +18,7 @@ arma::sp_mat spdiags(const arma::mat& B, const std::vector<int>& d, int m, int n
 
     return A;
 }
-
+#endif
 
 // This is a OpenCV-based implementation of conv2 in Matlab.
 cv::Mat conv2(const cv::Mat &img, const cv::Mat& ikernel, ConvolutionType type)


### PR DESCRIPTION
1. Build with modern OpenCV 4.x
2. Add option in CMake for USE_ARMA for disable algorithms with armadillo and dlib dependences
3. Add CLAHE test from OpenCV library